### PR TITLE
Fix gh pages link

### DIFF
--- a/.github/workflows/jsdoc-build.yaml
+++ b/.github/workflows/jsdoc-build.yaml
@@ -20,5 +20,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          publish_dir: ./docs/jsjiit
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .vscode
 docs
 node_modules
-jsdoc.conf.json
 cert.pem
 key.pem
 dist


### PR DESCRIPTION
Fixes #2 

Now documentation will be accessible from https://codeblech.github.io/jsjiit/0.0.11

 