### PR TITLE
Addition of MOOC and ADD/DROP Subject status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsjiit",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsjiit",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "license": "ISC",
       "devDependencies": {
         "esbuild": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsjiit",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Browser-compatible API for interacting with JIIT (Jaypee Institute of Information Technology) WebPortal. Bypasses CAPTCHA :)",
   "main": "src/index.js",
   "module": "dist/jsjiit.esm.js",

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -9,7 +9,7 @@ import {
 import { RegisteredSubject, Registrations } from "./registration.js";
 import { AttendanceMeta, AttendanceHeader, Semester } from "./attendance.js";
 import { ExamEvent } from "./exam.js";
-import { generate_local_name, serialize_payload } from "./encryption.js";
+import { base64Encode, encrypt, generate_local_name, serialize_payload } from "./encryption.js";
 
 /**
  * @module Wrapper
@@ -801,6 +801,35 @@ export class WebPortal {
     return resp["response"];
   }
 
+  async get_add_drop_status_semesters() {
+    const ENDPOINT = "/adddropsubjectstatus/getsemestercodelist";
+    const bypassValue = base64Encode(
+      await encrypt(new TextEncoder().encode(this.session.regdata.bypass)),
+    );
+    const payload = {
+      instituteid: this.session.instituteid,
+      bypassValue,
+    };
+    const resp = await this.__hit("POST", this.apiUrl + ENDPOINT, {
+      json: payload,
+      authenticated: true,
+    });
+    return resp["response"];
+  }
+
+  async get_add_drop_status(semester) {
+    const ENDPOINT = "/adddropsubjectstatus/getsubjectstatus";
+    const payload = {
+      instituteid: this.session.instituteid,
+      registrationid: semester.registration_id,
+    };
+    const resp = await this.__hit("POST", this.apiUrl + ENDPOINT, {
+      json: payload,
+      authenticated: true,
+    });
+    return resp["response"];
+  }
+
   async get_hostel_details() {
     const ENDPOINT = "/myhostelallocationdetail/gethostelallocationdetail";
     const payload = {
@@ -973,6 +1002,8 @@ const authenticatedMethods = [
   "get_hostel_details",
   "get_mooc_subject_status_semesters",
   "get_mooc_subject_status",
+  "get_add_drop_status_semesters",
+  "get_add_drop_status",
   "get_fines_msc_charges",
   "get_fee_summary",
   "get_subject_choices",

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -776,6 +776,31 @@ export class WebPortal {
     return resp["response"];
   }
 
+  async get_mooc_subject_status_semesters() {
+    const ENDPOINT = "/moocsubjectstatus/getsemestercodelist";
+    const payload = {
+      instituteid: this.session.instituteid,
+    };
+    const resp = await this.__hit("POST", this.apiUrl + ENDPOINT, {
+      json: payload,
+      authenticated: true,
+    });
+    return resp["response"];
+  }
+
+  async get_mooc_subject_status(semester) {
+    const ENDPOINT = "/moocsubjectstatus/getsubjectstatus";
+    const payload = {
+      instituteid: this.session.instituteid,
+      registrationid: semester.registration_id,
+    };
+    const resp = await this.__hit("POST", this.apiUrl + ENDPOINT, {
+      json: payload,
+      authenticated: true,
+    });
+    return resp["response"];
+  }
+
   async get_hostel_details() {
     const ENDPOINT = "/myhostelallocationdetail/gethostelallocationdetail";
     const payload = {
@@ -946,6 +971,8 @@ const authenticatedMethods = [
   "__get_semester_number",
   "get_sgpa_cgpa",
   "get_hostel_details",
+  "get_mooc_subject_status_semesters",
+  "get_mooc_subject_status",
   "get_fines_msc_charges",
   "get_fee_summary",
   "get_subject_choices",

--- a/test.html
+++ b/test.html
@@ -89,6 +89,12 @@
       // let marks = await w.download_marks(latestSem);
       // console.log(marks);
 
+      const moocSems = await w.get_mooc_subject_status_semesters();
+      console.log("MOOC semesters:", moocSems);
+      const sem = moocSems[0];
+      const moocStatus = await w.get_mooc_subject_status({ registration_id: sem.registrationid });
+      console.log("MOOC status:", moocStatus);
+
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary

Adds read-only MOOC and Add/Drop subject status APIs.

- Adds MOOC semester/status methods
- Adds Add/Drop semester/status methods
- Uses the session bypass value required by the Add/Drop semester endpoint
- Bumps package version to `0.0.28`

## Verification

- MOOC status was verified against a live student account
- Add/Drop status request was verified against a live student account; when no event is active, JIIT returns `No Regeistration Event found!`
